### PR TITLE
Fixes for instance specific settings

### DIFF
--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -46,7 +46,7 @@ while :
 do
     if [[ -v FAH_USERNAME ]]; then
         FAH_CURRENT_USERNAME=$(.local/bin/lufah -a / config user)
-        if [[ $FAH_CURRENT_USERNAME != "\$FAH_USERNAME\"" ]]
+        if [[ $FAH_CURRENT_USERNAME != "\"$FAH_USERNAME\"" ]]
         then
             echo "FAH username specified.  Updating FAH config"
             .local/bin/lufah -a / config user $FAH_USERNAME
@@ -56,7 +56,7 @@ do
 
     if [[ -v FAH_TEAM ]]; then
         FAH_CURRENT_TEAM=$(.local/bin/lufah -a / config team)
-        if [[ $FAH_CURRENT_TEAM != "\$FAH_TEAM\"" ]]
+        if [[ $FAH_CURRENT_TEAM != "\"$FAH_TEAM\"" ]]
         then
             echo "FAH team specified.  Updating FAH config"
             .local/bin/lufah -a / config team $FAH_TEAM
@@ -66,7 +66,7 @@ do
 
     if [[ -v FAH_PASSKEY ]]; then
         FAH_CURRENT_PASSKEY=$(.local/bin/lufah -a / config passkey)
-        if [[ $FAH_CURRENT_PASSKEY != "\$FAH_PASSKEY\"" ]]
+        if [[ $FAH_CURRENT_PASSKEY != "\"$FAH_PASSKEY\"" ]]
         then
             echo "FAH passkey specified.  Updating FAH config"
             .local/bin/lufah -a / config passkey $FAH_PASSKEY
@@ -79,7 +79,7 @@ do
         echo "FAH autostart enabled."
 
         FAH_CURRENT_USERNAME=$(.local/bin/lufah -a / config user)
-        if [[ -v FAH_USERNAME && $FAH_CURRENT_USERNAME != "\$FAH_USERNAME\"" ]]
+        if [[ -v FAH_USERNAME && $FAH_CURRENT_USERNAME != "\"$FAH_USERNAME\"" ]]
         then
             echo "Configured user does not match the specified user.  Will retry configuration"
             sleep 1
@@ -87,7 +87,7 @@ do
         fi
         
         FAH_CURRENT_TEAM=$(.local/bin/lufah -a / config team)
-        if [[ -v FAH_TEAM && $FAH_CURRENT_TEAM != "\$FAH_TEAM\"" ]]
+        if [[ -v FAH_TEAM && $FAH_CURRENT_TEAM != "\"$FAH_TEAM\"" ]]
         then
             echo "Configured team does not match the specified team.  Will retry configuration"
             sleep 1
@@ -95,7 +95,7 @@ do
         fi
         
         FAH_CURRENT_PASSKEY=$(.local/bin/lufah -a / config passkey)
-        if [[ -v FAH_PASSKEY && $FAH_CURRENT_PASSKEY != "\$FAH_PASSKEY\"" ]]
+        if [[ -v FAH_PASSKEY && $FAH_CURRENT_PASSKEY != "\"$FAH_PASSKEY\"" ]]
         then
             echo "Configured passkey does not match the specified passkey.  Will retry configuration"
             sleep 1

--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -81,7 +81,7 @@ do
         FAH_CURRENT_USERNAME=$(.local/bin/lufah -a / config user)
         if [[ -v FAH_USERNAME && $FAH_CURRENT_USERNAME != "\"$FAH_USERNAME\"" ]]
         then
-            echo "Configured user does not match the specified user.  Will retry configuration"
+            echo "Configured user ($FAH_CURRENT_USERNAME) does not match the specified user.  Will retry configuration"
             sleep 1
             continue;
         fi
@@ -89,7 +89,7 @@ do
         FAH_CURRENT_TEAM=$(.local/bin/lufah -a / config team)
         if [[ -v FAH_TEAM && $FAH_CURRENT_TEAM != "\"$FAH_TEAM\"" ]]
         then
-            echo "Configured team does not match the specified team.  Will retry configuration"
+            echo "Configured team ($FAH_CURRENT_TEAM) does not match the specified team.  Will retry configuration"
             sleep 1
             continue;
         fi
@@ -97,7 +97,7 @@ do
         FAH_CURRENT_PASSKEY=$(.local/bin/lufah -a / config passkey)
         if [[ -v FAH_PASSKEY && $FAH_CURRENT_PASSKEY != "\"$FAH_PASSKEY\"" ]]
         then
-            echo "Configured passkey does not match the specified passkey.  Will retry configuration"
+            echo "Configured passkey ($FAH_CURRENT_PASSKEY) does not match the specified passkey.  Will retry configuration"
             sleep 1
             continue;
         fi

--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -27,7 +27,7 @@
 
 FAH_MACHINE_NAME="Vast.ai-$VAST_CONTAINERLABEL"
 if [[ -v FAH_USERNAME ]]; then
-    echo "FAH username specified; Adding to machine name"
+    echo "FAH username specified; Updating machine name"
     FAH_MACHINE_NAME=$FAH_MACHINE_NAME-$FAH_USERNAME
 fi
 
@@ -40,29 +40,76 @@ sleep 10
 echo "Enabling all GPUs"
 .local/bin/lufah -a / enable-all-gpus
 
-if [[ -v FAH_USERNAME ]]; then
-    echo "FAH username specified.  Updating FAH config"
-    .local/bin/lufah -a / config user $FAH_USERNAME
-    .local/bin/lufah -a / config user
-fi
+echo "===================================="
+echo "Beginning FAH configuration loop"
+while :
+do
+    if [[ -v FAH_USERNAME ]]; then
+        FAH_CURRENT_USERNAME=$(.local/bin/lufah -a / config user)
+        if [[ $FAH_CURRENT_USERNAME != "\$FAH_USERNAME\"" ]]
+        then
+            echo "FAH username specified.  Updating FAH config"
+            .local/bin/lufah -a / config user $FAH_USERNAME
+            echo "---"
+        fi
+    fi
 
-if [[ -v FAH_TEAM ]]; then
-    echo "FAH team specified.  Updating FAH config"
-    .local/bin/lufah -a / config team $FAH_TEAM
-    .local/bin/lufah -a / config team
-fi
+    if [[ -v FAH_TEAM ]]; then
+        FAH_CURRENT_TEAM=$(.local/bin/lufah -a / config team)
+        if [[ $FAH_CURRENT_TEAM != "\$FAH_TEAM\"" ]]
+        then
+            echo "FAH team specified.  Updating FAH config"
+            .local/bin/lufah -a / config team $FAH_TEAM
+            echo "---"
+        fi
+    fi
 
-if [[ -v FAH_PASSKEY ]]; then
-    echo "FAH passkey specified.  Updating FAH config"
-    .local/bin/lufah -a / config passkey $FAH_PASSKEY
-    .local/bin/lufah -a / config passkey    
-fi
+    if [[ -v FAH_PASSKEY ]]; then
+        FAH_CURRENT_PASSKEY=$(.local/bin/lufah -a / config passkey)
+        if [[ $FAH_CURRENT_PASSKEY != "\$FAH_PASSKEY\"" ]]
+        then
+            echo "FAH passkey specified.  Updating FAH config"
+            .local/bin/lufah -a / config passkey $FAH_PASSKEY
+            echo "---"
+        fi
+    fi
 
 
+    if [[ -v FAH_AUTOSTART && $FAH_AUTOSTART = "true" ]]; then
+        echo "FAH autostart enabled."
 
-if [[ -v FAH_AUTOSTART && $FAH_AUTOSTART = "true" ]]; then
-    echo "FAH autostart enabled.  Folding is starting."
-    .local/bin/lufah -a / fold
-else
-    echo "FAH autostart disabled.  You will need to manually start folding on this machine"
-fi
+        FAH_CURRENT_USERNAME=$(.local/bin/lufah -a / config user)
+        if [[ -v FAH_USERNAME && $FAH_CURRENT_USERNAME != "\$FAH_USERNAME\"" ]]
+        then
+            echo "Configured user does not match the specified user.  Will retry configuration"
+            sleep 1
+            continue;
+        fi
+        
+        FAH_CURRENT_TEAM=$(.local/bin/lufah -a / config team)
+        if [[ -v FAH_TEAM && $FAH_CURRENT_TEAM != "\$FAH_TEAM\"" ]]
+        then
+            echo "Configured team does not match the specified team.  Will retry configuration"
+            sleep 1
+            continue;
+        fi
+        
+        FAH_CURRENT_PASSKEY=$(.local/bin/lufah -a / config passkey)
+        if [[ -v FAH_PASSKEY && $FAH_CURRENT_PASSKEY != "\$FAH_PASSKEY\"" ]]
+        then
+            echo "Configured passkey does not match the specified passkey.  Will retry configuration"
+            sleep 1
+            continue;
+        fi
+
+        echo "Configuration finished.  Folding starting"
+        #.local/bin/lufah -a / fold
+
+        # we only want to start folding once.  after one time, we enter the loop to ensure
+        # the configuration is still accurate (not overridden by account settings)
+        FAH_AUTOSTART=false
+    fi
+
+    # Sleep 5 seconds and then double check the config is accuate still
+    sleep 5
+done

--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -31,6 +31,9 @@ if [[ -v FAH_USERNAME ]]; then
     FAH_MACHINE_NAME=$FAH_MACHINE_NAME-$FAH_USERNAME
 fi
 
+# make the current environment variables available to a standard shell 
+env >> /etc/environment;
+
 echo "Starting fah-clinent"
 screen -dm ./fah-client --log=/var/log/fah-client/log.txt --log-rotate-dir=/var/log/fah-client/ --account-token=$FAH_ACCOUNT_TOKEN --machine-name=$FAH_MACHINE_NAME --cpus 0
 
@@ -82,6 +85,8 @@ do
         if [[ -v FAH_USERNAME && $FAH_CURRENT_USERNAME != "\"$FAH_USERNAME\"" ]]
         then
             echo "Configured user ($FAH_CURRENT_USERNAME) does not match the specified user.  Will retry configuration"
+            echo "---"
+            echo "---"
             sleep 1
             continue;
         fi
@@ -90,6 +95,8 @@ do
         if [[ -v FAH_TEAM && $FAH_CURRENT_TEAM != "$FAH_TEAM" ]]
         then
             echo "Configured team ($FAH_CURRENT_TEAM) does not match the specified team.  Will retry configuration"
+            echo "---"
+            echo "---"
             sleep 1
             continue;
         fi
@@ -98,12 +105,14 @@ do
         if [[ -v FAH_PASSKEY && $FAH_CURRENT_PASSKEY != "\"$FAH_PASSKEY\"" ]]
         then
             echo "Configured passkey ($FAH_CURRENT_PASSKEY) does not match the specified passkey.  Will retry configuration"
+            echo "---"
+            echo "---"
             sleep 1
             continue;
         fi
 
         echo "Configuration finished.  Folding starting"
-        #.local/bin/lufah -a / fold
+        .local/bin/lufah -a / fold
 
         # we only want to start folding once.  after one time, we enter the loop to ensure
         # the configuration is still accurate (not overridden by account settings)
@@ -113,5 +122,3 @@ do
     # Sleep 5 seconds and then double check the config is accuate still
     sleep 5
 done
-
-env >> /etc/environment;

--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -56,7 +56,7 @@ do
 
     if [[ -v FAH_TEAM ]]; then
         FAH_CURRENT_TEAM=$(.local/bin/lufah -a / config team)
-        if [[ $FAH_CURRENT_TEAM != "\"$FAH_TEAM\"" ]]
+        if [[ $FAH_CURRENT_TEAM != "$FAH_TEAM" ]]
         then
             echo "FAH team specified.  Updating FAH config"
             .local/bin/lufah -a / config team $FAH_TEAM
@@ -87,7 +87,7 @@ do
         fi
         
         FAH_CURRENT_TEAM=$(.local/bin/lufah -a / config team)
-        if [[ -v FAH_TEAM && $FAH_CURRENT_TEAM != "\"$FAH_TEAM\"" ]]
+        if [[ -v FAH_TEAM && $FAH_CURRENT_TEAM != "$FAH_TEAM" ]]
         then
             echo "Configured team ($FAH_CURRENT_TEAM) does not match the specified team.  Will retry configuration"
             sleep 1

--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -113,3 +113,5 @@ do
     # Sleep 5 seconds and then double check the config is accuate still
     sleep 5
 done
+
+env >> /etc/environment;

--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -42,18 +42,23 @@ echo "Enabling all GPUs"
 
 if [[ -v FAH_USERNAME ]]; then
     echo "FAH username specified.  Updating FAH config"
-    .local/bin/lufah -a / config user $FAH_USERNAME    
+    .local/bin/lufah -a / config user $FAH_USERNAME
+    .local/bin/lufah -a / config user
 fi
 
 if [[ -v FAH_TEAM ]]; then
     echo "FAH team specified.  Updating FAH config"
     .local/bin/lufah -a / config team $FAH_TEAM
+    .local/bin/lufah -a / config team
 fi
 
 if [[ -v FAH_PASSKEY ]]; then
     echo "FAH passkey specified.  Updating FAH config"
-    .local/bin/lufah -a / config passkey $FAH_PASSKEY    
+    .local/bin/lufah -a / config passkey $FAH_PASSKEY
+    .local/bin/lufah -a / config passkey    
 fi
+
+
 
 if [[ -v FAH_AUTOSTART && $FAH_AUTOSTART = "true" ]]; then
     echo "FAH autostart enabled.  Folding is starting."


### PR DESCRIPTION
fah-client will, at times, reset user, team and passkey settings from the attached fah account.  These changes will frequently check the local fah-client to ensure it is using the manually specified user, team and passkey.