### PR TITLE
Changes to support new vast.ai custom ubuntu image

### DIFF
--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -1,5 +1,8 @@
 # onstart script for Folding@Home v8 running on vast.ai
 
+  echo '**** ensuring we are in the /root  directory ****'
+  cd /root
+
   echo "**** install runtime packages ****" && \
   apt-get update && \
   apt-get install -y \

--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -10,7 +10,6 @@
     pipx && \
   pipx install lufah && \
    mkdir /var/log/fah-client && \
-  ln -s libOpenCL.so.1 /usr/lib/x86_64-linux-gnu/libOpenCL.so && \
   echo "**** install foldingathome ****" && \
   download_url="https://download.foldingathome.org/releases/public/fah-client/debian-10-64bit/release/fah-client_8.3.18-64bit-release.tar.bz2" && \
   curl -o \


### PR DESCRIPTION
When using CUDA > 12.4, FAH was not able to access the GPUs assigned to the instance.  Nicolas_orleans found an alternative image to use that resolves this issue.  These script changes are needed to support the new image as well as jupyter runtime mode instead of ssh