### PR TITLE
Upgrade fah-client to 8.5.5

### DIFF
--- a/fah-onstart.sh
+++ b/fah-onstart.sh
@@ -14,7 +14,7 @@
   pipx install lufah && \
    mkdir /var/log/fah-client && \
   echo "**** install foldingathome ****" && \
-  download_url="https://download.foldingathome.org/releases/public/fah-client/debian-10-64bit/release/fah-client_8.4.9-64bit-release.tar.bz2" && \
+  download_url="https://download.foldingathome.org/releases/public/fah-client/debian-10-64bit/release/fah-client_8.5.5-64bit-release.tar.bz2" && \
   curl -o \
     /tmp/fah.tar.bz2 -L \
     ${download_url} && \


### PR DESCRIPTION
Update to latest release of fah-client. v8.5.x required for large projects like 18261 that cannot be assigned to v8.4.9.